### PR TITLE
Upgrade to gs 9.52

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM lambci/lambda-base-2:build
-ENV GS_TAG=gs950
-ENV GS_VERSION=9.50
+ENV GS_TAG=gs952
+ENV GS_VERSION=9.52
 
 RUN yum install -y wget
 

--- a/publish.sh
+++ b/publish.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-GHOSTSCRIPT_VERSION=9.50
+GHOSTSCRIPT_VERSION=9.52
 LAYER_NAME='ghostscript'
 LAYER_VERSION=$(
   aws lambda publish-layer-version --region "$TARGET_REGION" \


### PR DESCRIPTION
Hi, this branch contains the upgrade to ghostscript 9.52. Here there are some news about the [9.52 version](https://www.ghostscript.com/doc/9.52/News.htm).

I've followed the listed points in the update section of the readme, I hope I did things right.