### PR TITLE
feat: upgrade to 9.55.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM lambci/lambda-base-2:build
-ENV GS_TAG=gs952
-ENV GS_VERSION=9.52
+ENV GS_TAG=gs9550
+ENV GS_VERSION=9.55.0
 
 RUN yum install -y wget
 

--- a/publish.sh
+++ b/publish.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-GHOSTSCRIPT_VERSION=9.52
+GHOSTSCRIPT_VERSION=9.55.0
 LAYER_NAME='ghostscript'
 LAYER_VERSION=$(
   aws lambda publish-layer-version --region "$TARGET_REGION" \


### PR DESCRIPTION
This PR updates Ghostscript to the current version 9.55.0.

Note: The official version number in addition to "major" and "minor" introduced kind of a "patch".
Just to double check that nothing else depends on the old format.