### PR TITLE
Update GS version to 9.56.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM lambci/lambda-base-2:build
-ENV GS_TAG=gs9550
-ENV GS_VERSION=9.55.0
+ENV GS_TAG=gs9561
+ENV GS_VERSION=9.56.1
 
 RUN yum install -y wget
 

--- a/publish.sh
+++ b/publish.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-GHOSTSCRIPT_VERSION=9.55.0
+GHOSTSCRIPT_VERSION=9.56.1
 LAYER_NAME='ghostscript'
 LAYER_VERSION=$(
   aws lambda publish-layer-version --region "$TARGET_REGION" \


### PR DESCRIPTION
This PR updates Ghostscript to the current version 9.56.1. Just followed [this PR](https://github.com/shelfio/ghostscript-lambda-layer/pull/14).

I'm not sure if README.md should be updated upfront or after publishing, let me know and I will commit the docs.