### PR TITLE
Ghostscript version 10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM lambci/lambda-base-2:build
-ENV GS_TAG=gs9561
-ENV GS_VERSION=9.56.1
+ENV GS_TAG=gs1000
+ENV GS_VERSION=10.0.0
 
 RUN yum install -y wget
 

--- a/ghostscript.zip
+++ b/ghostscript.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ce6e7486c171d009019ddbbfea3b6a94fb215b6c1ae36df5c869b857cc6128f8
-size 15593348
+oid sha256:6964d7a40a5d0a2db1a01e4318e5581d53c778efb321598a661bc77bf27f7a46
+size 15591126

--- a/publish.sh
+++ b/publish.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-GHOSTSCRIPT_VERSION=9.56.1
+GHOSTSCRIPT_VERSION=10.0.0
 LAYER_NAME='ghostscript'
 LAYER_VERSION=$(
   aws lambda publish-layer-version --region "$TARGET_REGION" \


### PR DESCRIPTION
I've built this on my Apple Silicon MBP using `docker buildx build --platform linux/amd64 -t gs-lambda-layer .`

Deployed and tested to a Node 16 Lambda on x86 (it doesn't seem to run on ARM Lambda runtimes)

Testing output:
```
START RequestId: 62724ed4-8438-48bb-8e7f-cfa358d54df5 Version: $LATEST
2022-12-05T11:46:25.277Z	62724ed4-8438-48bb-8e7f-cfa358d54df5	INFO	[
  null,
  'GPL Ghostscript 10.0.0 (2022-09-21)\n' +
    'Copyright (C) 2022 Artifex Software, Inc.  All rights reserved.\n' +
    'This software is supplied under the GNU AGPLv3 and comes with NO WARRANTY:\n' +
    'see the file COPYING for details.\n' +
    'Error: /undefinedfilename in (version)\n' +
    'Operand stack:\n' +
    '\n' +
    'Execution stack:\n' +
    '   %interp_exit   .runexec2   --nostringval--   --nostringval--   --nostringval--   2   %stopped_push   --nostringval--   --nostringval--   --nostringval--   false   1   %stopped_push\n' +
    'Dictionary stack:\n' +
    '   --dict:761/1123(ro)(G)--   --dict:0/20(G)--   --dict:75/200(L)--\n' +
    'Current allocation mode is local\n' +
    'Last OS error: No such file or directory\n',
  'GPL Ghostscript 10.00.0: Unrecoverable error, exit code 1\n'
]
2022-12-05T11:46:25.277Z	62724ed4-8438-48bb-8e7f-cfa358d54df5	INFO	GPL Ghostscript 10.0.0 (2022-09-21)
Copyright (C) 2022 Artifex Software, Inc.  All rights reserved.
This software is supplied under the GNU AGPLv3 and comes with NO WARRANTY:
see the file COPYING for details.
Error: /undefinedfilename in (version)
Operand stack:

Execution stack:
   %interp_exit   .runexec2   --nostringval--   --nostringval--   --nostringval--   2   %stopped_push   --nostringval--   --nostringval--   --nostringval--   false   1   %stopped_push
Dictionary stack:
   --dict:761/1123(ro)(G)--   --dict:0/20(G)--   --dict:75/200(L)--
Current allocation mode is local
Last OS error: No such file or directory

2022-12-05T11:46:25.277Z	62724ed4-8438-48bb-8e7f-cfa358d54df5	INFO	success
END RequestId: 62724ed4-8438-48bb-8e7f-cfa358d54df5
REPORT RequestId: 62724ed4-8438-48bb-8e7f-cfa358d54df5	Duration: 2914.55 ms	Billed Duration: 2915 ms	Memory Size: 128 MB	Max Memory Used: 98 MB	Init Duration: 148.06 ms
```