### PR TITLE
Update Ghostscipt to v10.02.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM lambci/lambda-base-2:build
-ENV GS_TAG=gs1000
-ENV GS_VERSION=10.0.0
+ENV GS_TAG=gs10020
+ENV GS_VERSION=10.02.0
 
 RUN yum install -y wget
 

--- a/ghostscript.zip
+++ b/ghostscript.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6964d7a40a5d0a2db1a01e4318e5581d53c778efb321598a661bc77bf27f7a46
-size 15591126
+oid sha256:327f7666c5fceaea4b1effe709ab6a9470972c3080080b35a9d69e1054fa9c93
+size 15592542

--- a/publish.sh
+++ b/publish.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-GHOSTSCRIPT_VERSION=10.0.0
+GHOSTSCRIPT_VERSION=10.02.0
 LAYER_NAME='ghostscript'
 LAYER_VERSION=$(
   aws lambda publish-layer-version --region "$TARGET_REGION" \


### PR DESCRIPTION
Hi we've noticed few issues with gh v10.0.0 when handing emoji/unicode fonts (some characters are missing after compression).
This looks to be fixed in 10.02 - hence this pr to bump gh to last version.